### PR TITLE
Add subcommands handling for dochelpers

### DIFF
--- a/doc/manpages/qubes-prefs.rst
+++ b/doc/manpages/qubes-prefs.rst
@@ -6,7 +6,7 @@
 Synopsis
 --------
 
-:command:`qubes-prefs` [-h] [--xml *XMLFILE*] [--verbose] [--quiet] [--force-root] [--help-properties] [*PROPERTY* [*VALUE*\|--delete]]
+:command:`qubes-prefs` [-h] [--verbose] [--quiet] [--force-root] [--help-properties] [*PROPERTY* [*VALUE*\|--delete]]
 
 Options
 -------
@@ -18,10 +18,6 @@ Options
 .. option:: --help-properties
 
    List available properties with short descriptions and exit.
-
-.. option:: --qubesxml=XMLFILE
-
-   Qubes OS store file.
 
 .. option:: --verbose, -v
 

--- a/doc/manpages/qvm-create.rst
+++ b/doc/manpages/qvm-create.rst
@@ -6,7 +6,7 @@
 Synopsis
 --------
 
-:command:`qvm-create` [-h] [--qubesxml *XMLFILE*] [--force-root] [--class *CLS*] [--property *NAME*=*VALUE*] [--template *VALUE*] [--label *VALUE*] [--root-copy-from *FILENAME* | --root-move-from *FILENAME*] *VMNAME*
+:command:`qvm-create` [-h] [--verbose] [--quiet] [--force-root] [--class *CLS*] [--property *NAME*=*VALUE*] [--pool *POOL_NAME:VOLUME_NAME*] [--template *VALUE*] --label *VALUE* [--root-copy-from *FILENAME* | --root-move-from *FILENAME*] *VMNAME*
 
 Options
 -------
@@ -15,9 +15,13 @@ Options
 
    show help message and exit
 
-.. option:: --qubesxml=XMLFILE
+.. option:: --verbose, -v
 
-   Qubes OS store file
+   Increase verbosity.
+
+.. option:: --quiet, -q
+
+   Decrease verbosity.
 
 .. option:: --force-root
 

--- a/doc/manpages/qvm-kill.rst
+++ b/doc/manpages/qvm-kill.rst
@@ -6,7 +6,7 @@
 Synopsis
 --------
 
-:command:`qvm-kill` skel-manpage.py [-h] [--verbose] [--quiet] *VMNAME*
+:command:`qvm-kill` [-h] [--verbose] [--quiet] [*VMNAME* [*VMNAME* ...]]
 
 Options
 -------

--- a/doc/manpages/qvm-ls.rst
+++ b/doc/manpages/qvm-ls.rst
@@ -6,8 +6,7 @@
 Synopsis
 --------
 
-:command:`qvm-ls` [*options*]
-
+:command:`qvm-ls` [-h] [--verbose] [--quiet] [--help-columns] [--help-formats] [--format *FORMAT* | --fields *FIELD*,...]
 
 Options
 -------
@@ -35,10 +34,13 @@ Options
    :option:`--format`. All columns along with short descriptions can be listed
    with :option:`--help-columns`.
 
-.. option:: --qubesxml=XMLFILE
+.. option:: --verbose, -v
 
-   Qubes store file
+   Increase verbosity.
 
+.. option:: --quiet, -q
+
+   Decrease verbosity.
 
 Authors
 -------

--- a/doc/manpages/qvm-prefs.rst
+++ b/doc/manpages/qvm-prefs.rst
@@ -6,7 +6,7 @@
 Synopsis
 --------
 
-:command:`qvm-prefs` qvm-prefs [-h] [--xml *XMLFILE*] [--verbose] [--quiet] [--force-root] [--help-properties] *VMNAME* [*PROPERTY* [*VALUE*\|--delete]]
+:command:`qvm-prefs` qvm-prefs [-h] [--verbose] [--quiet] [--force-root] [--help-properties] *VMNAME* [*PROPERTY* [*VALUE* \| --delete \| --default ]]
 
 Options
 -------
@@ -18,10 +18,6 @@ Options
 .. option:: --help-properties
 
    List available properties with short descriptions and exit.
-
-.. option:: --qubesxml=XMLFILE
-
-   Qubes OS store file.
 
 .. option:: --verbose, -v
 

--- a/doc/manpages/qvm-start.rst
+++ b/doc/manpages/qvm-start.rst
@@ -24,10 +24,6 @@ Options
 
    Show help message and exit.
 
-.. option:: --qubesxml=XMLFILE
-
-   Use another :file:`qubes.xml` file.
-
 .. option:: --verbose, -v
 
    Increase verbosity.
@@ -64,6 +60,10 @@ Options
 .. option:: --preparing-dvm
 
    Do actions necessary when preparing DVM image.
+
+.. option:: --skip-if-running
+   
+   Do not fail if the qube is already runnning
 
 .. option:: --no-start-guid
 

--- a/qubes/tools/__init__.py
+++ b/qubes/tools/__init__.py
@@ -291,6 +291,45 @@ class QubesArgumentParser(argparse.ArgumentParser):
         print(*args, file=sys.stderr, **kwargs)
 
 
+class AliasedSubParsersAction(argparse._SubParsersAction):
+    # source https://gist.github.com/sampsyo/471779
+    # pylint: disable=protected-access,too-few-public-methods
+    class _AliasedPseudoAction(argparse.Action):
+        # pylint: disable=redefined-builtin
+        def __init__(self, name, aliases, help):
+            dest = name
+            if aliases:
+                dest += ' (%s)' % ','.join(aliases)
+            sup = super(AliasedSubParsersAction._AliasedPseudoAction, self)
+            sup.__init__(option_strings=[], dest=dest, help=help)
+
+        def __call__(self, **kwargs):
+            super(AliasedSubParsersAction._AliasedPseudoAction, self).__call__(
+                **kwargs)
+
+    def add_parser(self, name, **kwargs):
+        if 'aliases' in kwargs:
+            aliases = kwargs['aliases']
+            del kwargs['aliases']
+        else:
+            aliases = []
+
+        local_parser = super(AliasedSubParsersAction, self).add_parser(
+            name, **kwargs)
+
+        # Make the aliases work.
+        for alias in aliases:
+            self._name_parser_map[alias] = local_parser
+        # Make the help text reflect them, first removing old help entry.
+        if 'help' in kwargs:
+            self._choices_actions.pop()
+            pseudo_action = self._AliasedPseudoAction(name, aliases,
+                                                      kwargs.pop('help'))
+            self._choices_actions.append(pseudo_action)
+
+        return local_parser
+
+
 def get_parser_for_command(command):
     '''Get parser for given qvm-tool.
 


### PR DESCRIPTION
- Add AliasedSubParsersAction for aliased sub commads i.e: qvm-block {list,ls,l}
- Dochelpers handle commands having subcommands, like `qvm-block`
  * Split the ArgumentCheckVisitor in an `OptionsCheckVisitor` &
    `SubCommandCheckVisitor`. The `OptionsCheckVisitor` checks options given in a
    section named 'Options' (case insensitive), while the
    `SubCommandCheckVisitor` dispatches on a section named 'Commands' (case
    insensitive).
- Fix finding the undocumented command arguments. The previous solution with
  `depart_document` did not work. `NodeVisitor` does not dispatch to
  `depart_document()` even if it's mentioned in the documentation. For details
  see `NodeVisitor.dispatch_departion()` implementation
- Dochelpers expect options which have help set to `argpase.SUPPRESS` to not show up in the manpage
- Fix manpages